### PR TITLE
Do not render empty div if there is no error message

### DIFF
--- a/src/components/FormError/FormError.tsx
+++ b/src/components/FormError/FormError.tsx
@@ -9,8 +9,10 @@ export const FormError: React.FunctionComponent<FormErrorPropType> = ({
   ...rest
 }) => {
   return (
-    <div className={classnames(className, classNames.formError.container)} {...rest}>
-      {children}
-    </div>
+    children && (
+      <div className={classnames(className, classNames.formError.container)} {...rest}>
+        {children}
+      </div>
+    )
   );
 };


### PR DESCRIPTION
Do not render empty div if there is no error message, because it is adding additional 8px to the components that are using the FormError component.