### PR TITLE
Remove select min width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clippings/paper",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Clippings Design System",
   "main": "build/index.js",
   "types": "src/index.d.ts",

--- a/src/assets/scss/select.scss
+++ b/src/assets/scss/select.scss
@@ -4,6 +4,7 @@
 .p-f-select {
   position: relative;
   display: flex;
+  min-width: 200px;
 
   svg {
     transition: transform 240ms;
@@ -20,7 +21,6 @@
     box-sizing: border-box;
     padding: 14px 16px;
     margin-left: 4px;
-    min-width: 200px;
     border-radius: $form-input-border-radius;
     width: 100%;
     cursor: pointer;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -9,7 +9,7 @@ import { SelectPropsType } from './types/SelectPropsType';
 
 export const Select: React.FunctionComponent<SelectPropsType> = forwardRef(
   (
-    { options, selected = null, placeholder = '', name = '', onChange = null },
+    { options, selected = null, placeholder = '', name = '', onChange = null, className = '' },
     ref: RefObject<HTMLInputElement>
   ) => {
     const selectedOptions = options.filter(option => option.value === selected);
@@ -29,9 +29,13 @@ export const Select: React.FunctionComponent<SelectPropsType> = forwardRef(
 
     return (
       <div
-        className={classnames(classNames.select.wrapper, {
-          open: isOpen,
-        })}
+        className={classnames(
+          classNames.select.wrapper,
+          {
+            open: isOpen,
+          },
+          className
+        )}
         ref={selectRef}
       >
         <div className={classNames.select.labelWrap} role="presentation" onClick={handleToggle}>

--- a/src/components/Select/types/SelectPropsType.ts
+++ b/src/components/Select/types/SelectPropsType.ts
@@ -9,4 +9,5 @@ export type SelectPropsType = {
   placeholder?: string;
   onChange?: (value: string) => void;
   name?: string;
+  className?: string;
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -85,7 +85,6 @@ export declare const Label: React.FunctionComponent<LabelPropType>;
 export declare const Button: React.FunctionComponent<ButtonPropsType>;
 
 export declare const CircleButton: React.FunctionComponent<ButtonPropsType>;
-export declare const Overlay: React.FunctionComponent<OverlayPropsType>;
 
 export declare const Overlay: React.FunctionComponent<OverlayPropsType>;
 


### PR DESCRIPTION
We don't need a min width for the select. It stretches further than the parent element and breaks some mobile designs