### PR TITLE
DEM-1953 Added ref to the badge component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clippings/paper",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Clippings Design System",
   "main": "build/index.js",
   "types": "src/index.d.ts",

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -20,7 +20,6 @@ export const Badge: React.FunctionComponent<BadgeInterface> = forwardRef(
       className={`${classNames.badge[type]} ${classNames.badge[size]} ${className}`}
       {...rest}
     >
-      <span>Badge</span>
       {children}
     </span>
   )

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,16 +1,27 @@
-import React from 'react';
+import React, { forwardRef, RefObject } from 'react';
 import { BADGE_TYPE } from './enums/BadgeTypeEnum';
 import { BADGE_SIZE } from './enums/BadgeSizeEnum';
 import classNames from '@core/config/ClassNames';
 import { BadgeInterface } from './types/BagdePropsType';
 
-export const Badge: React.FunctionComponent<BadgeInterface> = ({
-  className = '',
-  type = BADGE_TYPE.UNSPECIFIED,
-  size = BADGE_SIZE.SMALL,
-  children = null,
-}) => (
-  <span className={`${classNames.badge[type]} ${classNames.badge[size]} ${className}`}>
-    {children}
-  </span>
+export const Badge: React.FunctionComponent<BadgeInterface> = forwardRef(
+  (
+    {
+      className = '',
+      type = BADGE_TYPE.UNSPECIFIED,
+      size = BADGE_SIZE.SMALL,
+      children = null,
+      ...rest
+    },
+    ref: RefObject<HTMLInputElement>
+  ) => (
+    <span
+      ref={ref}
+      className={`${classNames.badge[type]} ${classNames.badge[size]} ${className}`}
+      {...rest}
+    >
+      <span>Badge</span>
+      {children}
+    </span>
+  )
 );


### PR DESCRIPTION
The react-bootstrap OverlayTrigger component,  that we use for the tooltips, requires the triggering components to accept a ref.