### PR TITLE
KZ-712 Use locale aware date format for date input

### DIFF
--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -9,7 +9,7 @@ import { DateInputPropsTypes } from './types/DateInputPropsTypes';
 
 export const DateInput: React.FunctionComponent<DateInputPropsTypes> = ({
   className = '',
-  dateFormat = 'dd/MM/yyyy',
+  dateFormat = 'P',
   maxDate,
   minDate,
   onChange,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import './assets/scss/components.scss';
 import './assets/scss/forms.scss';
 
+export { registerLocale, setDefaultLocale } from 'react-datepicker';
 export { ThemeProvider, ServerStyleSheet } from 'styled-components';
 export * from './index.components';
 export * from './index.enums';


### PR DESCRIPTION
Use locale aware date format by default for the date input component. 
The application's default locale will be set as part of https://clippings.atlassian.net/browse/KZ-712