### PR TITLE
Select Arrow Positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clippings/paper",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "description": "Clippings Design System",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/components/Select/styles/SelectStyles.ts
+++ b/src/components/Select/styles/SelectStyles.ts
@@ -13,7 +13,7 @@ export const selectStyles = makeStyles(() => ({
   },
   icon: {
     color: graphite120,
-    paddingRight: '6px',
+    right: '6px',
     fontSize: '24px',
     width: 'auto',
   },


### PR DESCRIPTION
Use the right property to position the icon instead of margin/padding, so that the rotation center is moved as well