### PR TITLE
Change the font size for small type heading

### DIFF
--- a/src/assets/scss/components.scss
+++ b/src/assets/scss/components.scss
@@ -69,7 +69,7 @@
 }
 
 .p-heading__small {
-  @extend %text-250e;
+  @extend %display-100;
 }
 
 .p-heading__medium {


### PR DESCRIPTION
The heading sizes should be as per the [design](https://www.figma.com/file/L5UGvwtakBVBVdkDkED7s9/Clippings.com?node-id=922%3A0) 

All the places that this change affects are addressed in https://github.com/clippings/clippings/pull/8467


NOTE: Additional step should be taken to match the size names to the design